### PR TITLE
Orca5

### DIFF
--- a/qforce/qm/orca.py
+++ b/qforce/qm/orca.py
@@ -1,4 +1,5 @@
 import os.path
+import re
 
 from colt import Colt
 import numpy as np
@@ -457,7 +458,7 @@ class ReadORCA(ReadABC):
             A list (length: n_atoms) of list (length: n_atoms) of float.
             representing the bond order between each atom pair.
         """
-
+        item_match = re.compile('^\(\s*(\d+)-\w{1,2}\s*,\s*(\d+)-\w{1,2}\s*\)\s*:\s*(-?\w.+)$')
         b_orders = [[0, ] * n_atoms for _ in range(n_atoms)]
 
         file = open(out_file, 'r')
@@ -472,9 +473,10 @@ class ReadORCA(ReadABC):
             for item in items:
                 if item.strip():
                     item = item.split()
-                    i = int(item[1].split('-')[0])
-                    j = int(item[3].split('-')[0])
-                    bond_order = float(item[-1])
+                    _m = re.match(item_match, item)
+                    i = int(_m.group(1))
+                    j = int(_m.group(2))
+                    bond_order = float(_m.group(3))
                     b_orders[i][j] = bond_order
                     b_orders[j][i] = bond_order
             line = file.readline()

--- a/qforce/qm/orca.py
+++ b/qforce/qm/orca.py
@@ -472,7 +472,6 @@ class ReadORCA(ReadABC):
             items = line.split('B')
             for item in items:
                 if item.strip():
-                    item = item.split()
                     _m = re.match(item_match, item)
                     i = int(_m.group(1))
                     j = int(_m.group(2))


### PR DESCRIPTION
Qforce did not parse bond orders from an output file generated using orca 5.0.3 splitting lines based on spaces. This patch uses regular expressions instead. I have not tested it on any other versions of orca, but it should be compatible with orca 5.x.x and might be backwards compatible with orca 4.