### PR TITLE
Implementation of ABF PES scanning for MM

### DIFF
--- a/qforce/data/default_md.mdp
+++ b/qforce/data/default_md.mdp
@@ -1,0 +1,53 @@
+; MDP file
+
+; Run parameters
+integrator              = md                ; leap-frog integrator
+nsteps                  = 10000000          ; 10'000'000 = 3 ns
+dt                      = 0.0001            ; in ps (0.001 = 1 fs)
+nstcomm                 = 1                 ; freq. for cm-motion removal
+ld_seed                 = -1
+
+; Bond constraints
+continuation            = no                ; continue from npt equilibration
+constraints             = none              ; constrain hydrogen bond lengths
+constraint_algorithm    = lincs             ; default
+lincs_order             = 4                 ; default
+
+; X/V/F/E outputs
+nstxout                 = 50000            ; pos out   ---  1000  ps
+nstvout                 = 50000            ; vel out   ---  1000  ps
+nstfout                 = 0                 ; force out ---  no
+nstlog                  = 50000             ; energies to log (20 ps)
+nstenergy               = 50000               ; energies to energy file
+nstxout-compressed      = 500               ; xtc, 1 ps
+compressed-x-precision  = 100000
+
+; Neighbour list
+cutoff-scheme           = Verlet            ;
+ns_type                 = grid              ; neighlist type
+nstlist                 = 20                ; Freq. to update neighbour list
+rlist                   = 1.2               ; nm (cutoff for short-range NL)
+
+; Coulomb interactions
+coulombtype             = Cut-off
+rcoulomb                = 1.1                ; nm (direct space sum cut-off)
+;optimize_fft            = yes               ; optimal FFT plan for the grid
+
+; van der Waals interactions
+vdwtype                 = Cut-off           ; Van der Waals interactions
+rvdw                    = 1.1               ; nm (LJ cut-off)
+DispCorr                = No                ; use dispersion correction
+
+; Energy monitoring
+energygrps              = System
+
+; Temperature coupling is on
+tcoupl                  = V-rescale         ; modified Berendsen thermostat
+tc-grps                 = MOL  Argon        ; two coupling groups - more accurate
+tau_t                   = 1.0   1.0         ; time constant, in ps
+ref_t                   = 273   273         ; reference temperature, one for each group, in K
+
+; Periodic boundary conditions
+pbc                     = xyz               ; 3-D PBC
+; Velocity generation
+gen_vel                 = yes

--- a/qforce/dihedral_scan.py
+++ b/qforce/dihedral_scan.py
@@ -1,3 +1,4 @@
+# fmt: off
 import subprocess
 import os
 import shutil
@@ -18,6 +19,9 @@ from colt import Colt
 from .forcefield import ForceField
 from .calculator import QForce
 from .forces import get_dihed, get_dist
+
+from pprint import pprint
+from typing import List, Tuple
 
 """
 
@@ -46,7 +50,7 @@ conj_bo_cutoff = 1.4 :: float
 break_co_bond = no :: bool
 
 # Method for doing the MM relaxed dihedral scan
-method = qforce :: str :: [qforce, gromacs]
+method = qforce :: str :: [qforce, gromacs, abf]
 
 # The executable for gromacs - necessary if scan method is gromacs
 gromacs_exec = gmx :: str
@@ -71,6 +75,7 @@ batch_run = False :: bool
 """
 
     def __init__(self, fragments, mol, job, all_config):
+        self.job = job
         self.frag_dir = job.frag_dir
         self.job_name = job.name
         self.mdp_file = f'{job.md_data}/default.mdp'
@@ -78,6 +83,8 @@ batch_run = False :: bool
         self.symmetrize = self._set_symmetrize()
         self.scan = getattr(self, f'scan_dihed_{self.config.method.lower()}')
         self.move_capping_atoms(fragments)
+
+        print(f"---------- Scanning with {self.config.method.lower()} ----------")
 
         fragments, all_dih_terms, weights = self.arrange_data(mol, fragments)
         final_energy, params = self.scan_dihedrals(fragments, mol, all_config, all_dih_terms,
@@ -163,17 +170,24 @@ batch_run = False :: bool
             print('         Please check manually to see if you find the accuracy satisfactory.\n')
 
     def scan_dihedrals(self, fragments, mol, all_config, all_dih_terms, weights):
+        removedir = []
+
         for n_run in range(self.config.n_dihed_scans):
             energy_diffs, md_energies = [], []
+
             for n_fit, frag in enumerate(fragments, start=1):
                 print(f'Run {n_run+1}/{self.config.n_dihed_scans}, fitting dihedral '
                       f'{n_fit}/{len(fragments)}: {frag.id}')
 
                 scan_dir = f'{self.frag_dir}/{frag.id}'
-                make_scan_dir(scan_dir)
+
+                if frag.id not in removedir:
+                    make_scan_dir(scan_dir)
+                    removedir.append(frag.id)
 
                 for term in frag.fit_terms:
                     term['angles'] = []
+
 
                 md_energy = self.scan(all_config, frag, scan_dir, mol, n_run)
                 md_energy -= md_energy.min()
@@ -245,6 +259,8 @@ batch_run = False :: bool
         ff = ForceField(self.job_name, all_config, frag, frag.neighbors,
                         exclude_all=frag.remove_non_bonded)
 
+        pprint(frag.fit_terms)
+
         for i, coord in enumerate(frag.coords):
             step_dir = f"{scan_dir}/step{i:02d}"
             make_scan_dir(step_dir)
@@ -262,7 +278,137 @@ batch_run = False :: bool
             coords = read(f'{step_dir}/geom.gro').get_positions()
             self.calc_fit_angles(frag, coords)
             frag.coords[i] = coords
+        
+        for i, term in enumerate(frag.fit_terms):
+            print(f"Angle series (original, rad) {i}: {term['angles']}")
+            print(f"Angle series (deg) {i}: {np.degrees(term['angles'])}")
+
         return np.array(md_energies)
+    
+# fmt: on
+    def scan_dihed_abf(self, all_config, frag, scan_dir, mol, n_run):
+        ff = ForceField(
+            self.job_name,
+            all_config,
+            frag,
+            frag.neighbors,
+            exclude_all=frag.remove_non_bonded
+        )
+
+        # QM angles
+        step_size = all_config.qm.scan_step_size
+        first_qm_coord = frag.coords[0]
+        qm_term = frag.fit_terms[0] # term containing atom indices of the "main" scanned dihedral
+        first_qm_angle = np.degrees(get_dihed(first_qm_coord[qm_term['atomids']])[0])
+        last_qm_angle = first_qm_angle + ((360/step_size)-1)*step_size
+        wraparound = first_qm_angle+180
+
+        # Managing angles
+        #angle_series = []
+
+        for term in frag.fit_terms:
+            angles = []
+            for coord in frag.coords:
+                angle = get_dihed(coord[term['atomids']])[0]
+                angles.append(angle)
+            
+            term['angles'] = angles
+            pprint(term)
+
+        
+            
+        #     coord = frag.coords[0]
+        #     first_angle = get_dihed(coord[term['atomids']])[0]
+        #     first_angles.append(first_angle)
+
+        # for term in frag.fit_terms:
+        #     coord = frag.coords[0]
+        #     first_angle = get_dihed(coord[term['atomids']])[0]
+        #     first_angles.append(first_angle)
+
+        # pprint(frag.fit_terms)
+
+        # print("First angles (rad): ", first_angles)
+        # print("First angles (deg):", np.degrees(first_angles))
+    
+        # ref_angle, *other_angles = first_angles
+        
+        # ref_serie, other_series = calculate_angle_series(ref_angle, other_angles, step_size, rad=True,)
+
+        # angle_series = [ list(ref_serie) ] + [ serie.tolist() for serie in other_series ]
+
+        # for i, term in enumerate(frag.fit_terms):
+        #     term['angles'] = angle_series[i]
+
+        # for i, term in enumerate(frag.fit_terms):
+        #     print(f"Angle series {i}: {np.degrees(term['angles'])}")
+
+        run_dir = f"{scan_dir}/abf_run_{n_run}"
+        make_scan_dir(run_dir)
+
+        ff.write_gromacs(run_dir, frag, frag.coords[0], abf=True)
+        shutil.copy2(f'{self.job.md_data}/default_md.mdp', run_dir)
+
+        index1, index2, index3, index4 = frag.scanned_atomids
+        
+
+        colvar_string = f"""colvar {{
+  name phi
+  width {step_size}
+  lowerBoundary {first_qm_angle}
+  upperBoundary {last_qm_angle}
+  # H C C H
+  dihedral {{
+    wraparound {wraparound}
+    group1 {{ atomNumbers {index1+1}}}
+    group2 {{ atomNumbers {index2+1}}}
+    group3 {{ atomNumbers {index3+1}}}
+    group4 {{ atomNumbers {index4+1}}}
+  }}
+  extendedLagrangian on
+  extendedFluctuation 0.3
+}}
+abf {{
+ colvars phi
+ fullSamples 200
+}}"""
+        with open(f"{run_dir}/colvars.dat", "w") as colvarsfile:
+            colvarsfile.write(colvar_string)
+
+        # create argon single atom pdb file on the fly
+        with open(f"{run_dir}/argon.pdb", "w") as argon_pdb_file:
+            argon_pdb_file.write("HETATM    1 Ar   UNL     1       0.000   0.000   0.000  1.00  0.00          Ar")
+
+        argon_itp_string = '''
+[ moleculetype ]
+; Name            nrexcl
+Argon          3
+
+[ atoms ]
+;   nr       type  resnr residue  atom   cgnr    charge       mass  typeB    chargeB      massB
+; residue    1 RES rtp RES q 0.0
+    1   opls_097      1    Argon      Ar      1  0.00000000  39.948000   ; qtot  0.000000
+'''
+        with open(f"{run_dir}/argon.itp", "w") as argon_itp_file:
+            argon_itp_file.write(argon_itp_string)
+
+        gromacs_exec = all_config.scan.gromacs_exec
+
+        # create sample with gromacs insert
+        insert = subprocess.Popen([gromacs_exec, 'insert-molecules', '-f', 'gas.gro', '-ci', 'argon.pdb', '-nmol', '40', '-o', 'system.gro'],
+                                 cwd=run_dir, stdout=subprocess.PIPE,
+                                 stderr=subprocess.STDOUT)
+        insert.wait()
+        # run!
+        run_gromacs(run_dir, all_config.scan.gromacs_exec, ff.polar_title, abf = True)
+
+        energy = np.genfromtxt(f"{run_dir}/em.pmf", comments='#', usecols=1)
+
+        return energy
+    
+
+
+# fmt: off
 
     @staticmethod
     def calc_fit_angles(frag, coords):
@@ -382,7 +528,63 @@ batch_run = False :: bool
                                                 'end': get_periodic_angle(angles[i+1]),
                                                 'direct': direct[i] == '+'})
         return sym_dict
+# fmt: on
+def calculate_angle_series(
+    start_angle: float,
+    other_angles: List[float],
+    step: int,
+    rad: bool = False,
+) -> Tuple[np.ndarray, List[np.ndarray]]:
+    """
+    Generate a series of angles based on the provided start angle, a list of other angles, and step.
 
+    :param start_angle: The starting angle for calculation.
+    :param other_angles: A list of other angles to calculate the differences.
+    :param step: The step size.
+    :param rad: Boolean indicating if angles are in radians.
+    :return: A list containing the first series and a list of other series.
+    """
+
+    if rad:
+        start_angle = np.degrees(start_angle)
+
+    # Function to wrap angle between -180 and 180
+    def wrap_angle(angle: float) -> float:
+        angle = angle % 360
+        if angle > 180:
+            angle -= 360
+        return angle
+
+    # Generate first series from -180 to +180
+    series1 = np.array(range(-180, 180, int(step)))
+
+    other_series = []
+    for other_angle in other_angles:
+        if rad:
+            other_angle = np.degrees(other_angle)
+
+        # Calculate the difference and wrap it
+        angle_difference = wrap_angle(other_angle - start_angle)
+
+        # Generate series starting from angle_difference
+        series = np.array([wrap_angle(angle_difference - 180 + i * step) for i in range(len(series1))])
+        if rad:
+            series = np.radians(series)
+        other_series.append(series)
+
+    if rad:
+        series1 = np.radians(series1)
+
+    return series1, other_series
+
+
+# fmt: off
+
+def wrap_angle(angle: float) -> float:
+    angle = angle % 360
+    if angle > 180:
+        angle -= 360
+    return angle
 
 def get_periodic_angle(angle):
     if angle > 360:
@@ -393,6 +595,8 @@ def get_periodic_angle(angle):
 
 
 def get_periodic_angles(angles):
+    if isinstance(angles, list):
+        angles = np.array(angles)
     angles[angles > 360] -= 360
     angles[angles < 0] += 360
     return angles
@@ -419,10 +623,18 @@ def make_scan_dir(scan_name):
     os.makedirs(scan_name)
 
 
-def run_gromacs(directory, gromacs_exec, polar_title):
+def run_gromacs(directory, gromacs_exec, polar_title, abf=False):
+    if abf:
+        mdp_file = 'default_md.mdp'
+        structure_file = 'system.gro'
+        colvars = ['-colvars', 'colvars.dat']
+    else:
+        mdp_file = 'default.mdp'
+        structure_file = f'gas{polar_title}.gro'
+        colvars = []
     attempt, returncode = 0, 1
-    grompp = subprocess.Popen([gromacs_exec, 'grompp', '-f', 'default.mdp', '-p',
-                               f'gas{polar_title}.top', '-c', f'gas{polar_title}.gro', '-o',
+    grompp = subprocess.Popen([gromacs_exec, 'grompp', '-f', mdp_file, '-p',
+                               f'gas{polar_title}.top', '-c', structure_file, '-o',
                                'em.tpr', '-po', 'em.mdp', '-maxwarn', '10'],
                               cwd=directory, stdout=subprocess.PIPE,
                               stderr=subprocess.STDOUT)
@@ -430,7 +642,7 @@ def run_gromacs(directory, gromacs_exec, polar_title):
 
     while returncode != 0 and attempt < 5:
         check_gromacs_termination(grompp)
-        mdrun = subprocess.Popen([gromacs_exec, 'mdrun', '-deffnm', 'em'],
+        mdrun = subprocess.Popen([gromacs_exec, 'mdrun', '-nt', '1', '-deffnm', 'em', *colvars],
                                  cwd=directory, stdout=subprocess.PIPE,
                                  stderr=subprocess.STDOUT)
         mdrun.wait()
@@ -483,8 +695,13 @@ def calc_multi_rb_matrix(fragments, all_dih_terms, n_total_scans):
     matrix = np.zeros((n_total_scans, n_terms))
     for frag in fragments:
         n_scans = len(frag.qm_angles)
+        print("Number of scans: ", n_scans)
+
         for term in frag.fit_terms:
             term_idx = all_dih_terms.index(term['name'])
+            print("Scan sum: ", scan_sum)
+            print("term_idx: ", term_idx)
+            #print("calc_rb: ", calc_rb(term['angles']))
             matrix[scan_sum:scan_sum+n_scans,
                    term_idx*6:(term_idx*6)+6] += calc_rb(term['angles'])
         scan_sum += n_scans
@@ -507,3 +724,4 @@ def calc_rb_pot(params, angles):
     for i in range(1, 6):
         rb += params[i]*np.cos(np.array(angles)-np.pi)**i
     return rb
+# fmt: on

--- a/qforce/forcefield.py
+++ b/qforce/forcefield.py
@@ -1,4 +1,6 @@
+# fmt: off
 import numpy as np
+
 #
 from .elements import ATOM_SYM, ATOMMASS
 from .molecule.non_bonded import calc_sigma_epsilon
@@ -6,7 +8,7 @@ from .forces import convert_to_inversion_rb
 from .misc import LOGO_SEMICOL
 
 
-class ForceField():
+class ForceField:
     def __init__(self, job_name, config, mol, neighbors, exclude_all=[]):
         self.polar = config.ff._polar
         self.mol_name = job_name
@@ -23,27 +25,42 @@ class ForceField():
         self.masses = [round(ATOMMASS[i], 5) for i in self.elements]
         self.exclusions = self.make_exclusions(mol.non_bonded, neighbors, exclude_all)
         self.pairs = self.make_pairs(neighbors, mol.non_bonded)
+        self.mol = mol
+        self.config = config
 
         if self.polar:
-            self.polar_title = '_polar'
+            self.polar_title = "_polar"
         else:
-            self.polar_title = ''
+            self.polar_title = ""
 
-    def write_gromacs(self, directory, mol, coords):
-        self.write_itp(mol, directory)
-        self.write_top(directory)
-        self.write_gro(directory, coords, mol.non_bonded.alpha_map)
+    def write_gromacs(self, directory, mol, coords, abf=False):
+        self.write_itp(mol, directory, abf)
+        self.write_top(directory, abf)
+        if abf:
+            box = [5.0, 5.0, 5.0]
+            self.write_gro(directory, coords, mol.non_bonded.alpha_map, box=box)
+        else:
+            self.write_gro(directory, coords, mol.non_bonded.alpha_map)
 
-    def write_top(self, directory):
+    def write_top(self, directory, abf=False):
         with open(f"{directory}/gas{self.polar_title}.top", "w") as top:
             # defaults
             top.write("\n[ defaults ]\n")
             top.write("; nbfunc    comb-rule    gen-pairs      fudgeLJ      fudgeQQ\n")
-            top.write(f"{1:>8} {self.comb_rule:>12} {'yes':>12} {self.fudge_lj:>12} "
-                      f"{self.fudge_q:>12}\n\n\n")
+            top.write(
+                f"{1:>8} {self.comb_rule:>12} {'yes':>12} {self.fudge_lj:>12} "
+                f"{self.fudge_q:>12}\n\n\n"
+            )
 
             top.write("; Include the molecule ITP\n")
-            top.write(f'#include "./{self.mol_name}_qforce{self.polar_title}.itp"\n\n\n')
+            top.write(
+                f'#include "./{self.mol_name}_qforce{self.polar_title}.itp"\n'
+            )
+
+            if abf:
+                top.write('#include "argon.itp"\n')
+
+            top.write("\n\n")
 
             size = len(self.mol_name)
             top.write("[ system ]\n")
@@ -53,16 +70,20 @@ class ForceField():
             top.write("[ molecules ]\n")
             top.write(f"; {' '*(size-10)}compound    n_mol\n")
             top.write(f"{' '*(10-size)}{self.mol_name}        1\n")
+            if abf:
+                top.write("Argon       40\n")
 
-    def write_gro(self, directory, coords, alpha_map, box=[20., 20., 20.]):
+    def write_gro(self, directory, coords, alpha_map, box=[20.0, 20.0, 20.0]):
         n_atoms = self.n_atoms
         if self.polar:
             n_atoms += len(alpha_map.keys())
-        coords_nm = coords*0.1
+        coords_nm = coords * 0.1
         with open(f"{directory}/gas{self.polar_title}.gro", "w") as gro:
             gro.write(f"{self.mol_name}\n")
             gro.write(f"{n_atoms:>6}\n")
-            for i, (a_name, coord) in enumerate(zip(self.atom_names, coords_nm), start=1):
+            for i, (a_name, coord) in enumerate(
+                zip(self.atom_names, coords_nm), start=1
+            ):
                 gro.write(f"{1:>5}{self.residue:<5}")
                 gro.write(f"{a_name:>5}{i:>5}")
                 gro.write(f"{coord[0]:>8.3f}{coord[1]:>8.3f}{coord[2]:>8.3f}\n")
@@ -71,12 +92,14 @@ class ForceField():
                     gro.write(f"{2:>5}{self.residue:<5}{f'D{i}':>5}{drude+1:>5}")
                     gro.write(f"{coords_nm[atom][0]:>8.3f}{coords_nm[atom][1]:>8.3f}")
                     gro.write(f"{coords_nm[atom][2]:>8.3f}\n")
-            gro.write(f'{box[0]:>12.5f}{box[1]:>12.5f}{box[2]:>12.5f}\n')
+            gro.write(f"{box[0]:>12.5f}{box[1]:>12.5f}{box[2]:>12.5f}\n")
 
-    def write_itp(self, mol, directory):
-        with open(f"{directory}/{self.mol_name}_qforce{self.polar_title}.itp", "w") as itp:
+    def write_itp(self, mol, directory, abf):
+        with open(
+            f"{directory}/{self.mol_name}_qforce{self.polar_title}.itp", "w"
+        ) as itp:
             itp.write(LOGO_SEMICOL)
-            self.write_itp_atoms_and_molecule(itp, mol.non_bonded)
+            self.write_itp_atoms_and_molecule(itp, mol.non_bonded, abf)
             if self.polar:
                 self.write_itp_polarization(itp, mol.non_bonded)
             self.write_itp_bonds(itp, mol.terms, mol.non_bonded.alpha_map)
@@ -84,7 +107,7 @@ class ForceField():
             self.write_itp_dihedrals(itp, mol.terms)
             self.write_itp_pairs(itp)
             self.write_itp_exclusions(itp)
-            itp.write('\n')
+            itp.write("\n")
 
     def convert_to_gromacs_nonbonded(self, non_bonded):
         a_types, nb_pairs, nb_1_4 = {}, {}, {}
@@ -117,8 +140,10 @@ class ForceField():
 
         return a_types, nb_pairs, nb_1_4
 
-    def write_itp_atoms_and_molecule(self, itp, non_bonded):
-        gro_atomtypes, gro_nonbonded, gro_1_4 = self.convert_to_gromacs_nonbonded(non_bonded)
+    def write_itp_atoms_and_molecule(self, itp, non_bonded, abf):
+        gro_atomtypes, gro_nonbonded, gro_1_4 = self.convert_to_gromacs_nonbonded(
+            non_bonded
+        )
 
         # atom types
         itp.write("\n[ atomtypes ]\n")
@@ -129,7 +154,10 @@ class ForceField():
 
         for lj_type, lj_params in gro_atomtypes.items():
             itp.write(f'{lj_type:>8} {non_bonded.lj_atomic_number[lj_type]:>7} {0:>8.4f} {0:>8.4f} {"A":>5} ')
-            itp.write(f'{lj_params[0]:>12.5e} {lj_params[1]:>12.5e}\n')
+            itp.write(f"{lj_params[0]:>12.5e} {lj_params[1]:>12.5e}\n")
+        
+        if abf:
+            itp.write("opls_097      18   0.0000   0.0000     A  3.40100e-01  9.78638e-01")
 
         if self.polar:
             itp.write(f'{"DP":>8} {0:>8.4f} {0:>8.4f} {"S":>2} {0:>12.5e} {0:>12.5e}\n')
@@ -142,8 +170,8 @@ class ForceField():
             itp.write(";  name1    name2   type          sigma         epsilon\n")
 
         for lj_types, lj_params in gro_nonbonded.items():
-            itp.write(f'{lj_types[0]:>8} {lj_types[1]:>8}      1')
-            itp.write(f'{lj_params[0]:>15.5e} {lj_params[1]:>15.5e}\n')
+            itp.write(f"{lj_types[0]:>8} {lj_types[1]:>8}      1")
+            itp.write(f"{lj_params[0]:>15.5e} {lj_params[1]:>15.5e}\n")
 
         # Write 1-4 pair types
         if self.n_excl == 2 and gro_1_4 != {}:
@@ -153,11 +181,11 @@ class ForceField():
             else:
                 itp.write(";  name1    name2   type          sigma         epsilon\n")
             for lj_types, lj_params in gro_1_4.items():
-                itp.write(f'{lj_types[0]:>8} {lj_types[1]:>8}      1')
-                itp.write(f'{lj_params[0]:>15.5e} {lj_params[1]:>15.5e}\n')
+                itp.write(f"{lj_types[0]:>8} {lj_types[1]:>8}      1")
+                itp.write(f"{lj_params[0]:>15.5e} {lj_params[1]:>15.5e}\n")
 
         # molecule type
-        space = " "*(len(self.mol_name)-5)
+        space = " " * (len(self.mol_name) - 5)
         itp.write("\n[ moleculetype ]\n")
         itp.write(f";{space}name nrexcl\n")
         itp.write(f"{self.mol_name}{3:>7}\n")
@@ -165,22 +193,23 @@ class ForceField():
         # atoms
         itp.write("\n[ atoms ]\n")
         itp.write(";  nr      type  resnr  resnm    atom  cgrp      charge       mass\n")
-        for i, (lj_type, a_name, q, mass) in enumerate(zip(non_bonded.lj_types, self.atom_names,
-                                                           self.q, self.masses), start=1):
-            itp.write(f'{i:>5} {lj_type:>9} {1:>6} {self.residue:>6} {a_name:>7} {i:>5} ')
-            itp.write(f'{q:>11.5f} {mass:>10.5f}\n')
+        for i, (lj_type, a_name, q, mass) in enumerate(
+            zip(non_bonded.lj_types, self.atom_names, self.q, self.masses), start=1
+        ):
+            itp.write(f"{i:>5} {lj_type:>9} {1:>6} {self.residue:>6} {a_name:>7} {i:>5} ")
+            itp.write(f"{q:>11.5f} {mass:>10.5f}\n")
 
         if self.polar:
             for i, (atom, drude) in enumerate(non_bonded.alpha_map.items(), start=1):
                 itp.write(f'{drude+1:>5} {"DP":>9} {2:>6} {"DRU":>6} {f"D{i}":>7} {atom+1:>5}')
-                itp.write(f'{-8.:>11.5f} {0.:>10.5f}\n')
+                itp.write(f"{-8.:>11.5f} {0.:>10.5f}\n")
 
     def write_itp_polarization(self, itp, non_bonded):
         # polarization
         itp.write("\n[ polarization ]\n")
         itp.write(";    i      j      f          alpha\n")
         for atom, drude in non_bonded.alpha_map.items():
-            alpha = non_bonded.alpha[atom]*1e-3
+            alpha = non_bonded.alpha[atom] * 1e-3
             itp.write(f"{atom+1:>6} {drude+1:>6} {1:>6} {alpha:>14.8f}\n")
 
         # # thole polarization
@@ -201,99 +230,117 @@ class ForceField():
     def write_itp_bonds(self, itp, terms, alpha_map):
         itp.write("\n[ bonds ]\n")
         itp.write(";   ai     aj      f         r0     k_bond\n")
-        for bond in terms['bond']:
+        for bond in terms["bond"]:
             ids = bond.atomids + 1
             equ = bond.equ * 0.1
             fconst = bond.fconst * 100
-            itp.write(f'{ids[0]:>6} {ids[1]:>6} {1:>6} {equ:>10.5f} {fconst:>10.0f}\n')
+            itp.write(f"{ids[0]:>6} {ids[1]:>6} {1:>6} {equ:>10.5f} {fconst:>10.0f}\n")
 
         if self.polar:
-            itp.write(';   ai     aj      f - polar connections\n')
-            for bond in terms['bond']:
+            itp.write(";   ai     aj      f - polar connections\n")
+            for bond in terms["bond"]:
                 a1, a2 = bond.atomids
 
                 if a2 in alpha_map.keys():
-                    itp.write(f'{a1+1:>6} {alpha_map[a2]+1:>6} {5:>6}\n')
+                    itp.write(f"{a1+1:>6} {alpha_map[a2]+1:>6} {5:>6}\n")
                 if a1 in alpha_map.keys():
-                    itp.write(f'{a2+1:>6} {alpha_map[a1]+1:>6} {5:>6}\n')
+                    itp.write(f"{a2+1:>6} {alpha_map[a1]+1:>6} {5:>6}\n")
 
     def write_itp_angles(self, itp, terms):
         itp.write("\n[ angles ]\n")
         itp.write(";   ai     aj     ak      f     theta0    k_theta")
         if self.urey:
-            itp.write('         r0     k_bond')
-        itp.write('\n')
+            itp.write("         r0     k_bond")
+        itp.write("\n")
 
-        for angle in terms['angle']:
+        for angle in terms["angle"]:
             ids = angle.atomids + 1
             equ = np.degrees(angle.equ)
             fconst = angle.fconst
 
             if self.urey:
-                urey = [term for term in terms['urey'] if np.array_equal(term.atomids,
-                                                                         angle.atomids)]
+                urey = [
+                    term
+                    for term in terms["urey"]
+                    if np.array_equal(term.atomids, angle.atomids)
+                ]
             if not self.urey or len(urey) == 0:
-                itp.write(f'{ids[0]:>6} {ids[1]:>6} {ids[2]:>6} {1:>6} {equ:>10.3f} '
-                          f'{fconst:>10.3f}\n')
+                itp.write(f"{ids[0]:>6} {ids[1]:>6} {ids[2]:>6} {1:>6} {equ:>10.3f} "
+                    f"{fconst:>10.3f}\n")
             else:
                 urey_equ = urey[0].equ * 0.1
                 urey_fconst = urey[0].fconst * 100
-                itp.write(f'{ids[0]:>6} {ids[1]:>6} {ids[2]:>6} {5:>6} {equ:>10.3f} '
-                          f'{fconst:>10.3f} {urey_equ:>10.5f} {urey_fconst:>10.1f}\n')
+                itp.write(
+                    f"{ids[0]:>6} {ids[1]:>6} {ids[2]:>6} {5:>6} {equ:>10.3f} "
+                    f"{fconst:>10.3f} {urey_equ:>10.5f} {urey_fconst:>10.1f}\n"
+                )
 
     def write_itp_dihedrals(self, itp, terms):
-        if len(terms['dihedral']) > 0:
+        if len(terms["dihedral"]) > 0:
             itp.write("\n[ dihedrals ]\n")
 
         # rigid dihedrals
-        if len(terms['dihedral/rigid']) > 0:
+        if len(terms["dihedral/rigid"]) > 0:
             itp.write("; rigid dihedrals \n")
             itp.write(";   ai     aj     ak     al      f      theta0       k_theta\n")
 
-        for dihed in terms['dihedral/rigid']:
+        for dihed in terms["dihedral/rigid"]:
             ids = dihed.atomids + 1
             equ = np.degrees(dihed.equ)
             fconst = dihed.fconst
 
-            itp.write(f'{ids[0]:>6} {ids[1]:>6} {ids[2]:>6} {ids[3]:>6} {2:>6} {equ:>11.3f} ')
-            itp.write(f'{fconst:>13.3f}\n')
+            itp.write(f"{ids[0]:>6} {ids[1]:>6} {ids[2]:>6} {ids[3]:>6} {2:>6} {equ:>11.3f} ")
+            itp.write(f"{fconst:>13.3f}\n")
 
         # improper dihedrals
-        if len(terms['dihedral/improper']) > 0:
+        if len(terms["dihedral/improper"]) > 0:
             itp.write("; improper dihedrals \n")
             itp.write(";   ai     aj     ak     al      f      theta0       k_theta\n")
 
-        for dihed in terms['dihedral/improper']:
+        for dihed in terms["dihedral/improper"]:
             ids = dihed.atomids + 1
             equ = np.degrees(dihed.equ)
             fconst = dihed.fconst
 
-            itp.write(f'{ids[0]:>6} {ids[1]:>6} {ids[2]:>6} {ids[3]:>6} {2:>6} {equ:>11.3f} ')
-            itp.write(f'{fconst:>13.3f}\n')
+            itp.write(
+                f"{ids[0]:>6} {ids[1]:>6} {ids[2]:>6} {ids[3]:>6} {2:>6} {equ:>11.3f} "
+            )
+            itp.write(f"{fconst:>13.3f}\n")
 
         # flexible dihedrals
-        if len(terms['dihedral/flexible']) > 0:
+        if len(terms["dihedral/flexible"]) > 0:
             itp.write("; flexible dihedrals \n")
-            itp.write(';   ai     aj     ak     al      f          c0          c1          c2')
-            itp.write('          c3          c4          c5\n')
+            itp.write(";   ai     aj     ak     al      f          c0          c1          c2")
+            itp.write("          c3          c4          c5\n")
 
-        for dihed in terms['dihedral/flexible']:
+        for dihed in terms["dihedral/flexible"]:
+            # print("\033[31m From forcefield.py:ForceField:write_itp_dihedral: \033[0m")
+            # print(type(dihed))
+            # print(self.config.terms)
+            # print(self.mol.name, self.mol.dir)
+            # print(dihed.name, dihed.idx, dihed.atomids)
+            # print("Type of dihed.equ:")
+            # print(type(dihed.equ))
+            # print("Contents of dihed.equ:")
+            # print(dihed.equ)
             ids = dihed.atomids + 1
             c = dihed.equ
 
-            itp.write(f'{ids[0]:>6} {ids[1]:>6} {ids[2]:>6} {ids[3]:>6} {3:>6} {c[0]:>11.3f} ')
-            itp.write(f'{c[1]:>11.3f} {c[2]:>11.3f} {c[3]:>11.3f} {c[4]:>11.3f} {c[5]:>11.3f}\n')
+            itp.write(f"{ids[0]:>6} {ids[1]:>6} {ids[2]:>6} {ids[3]:>6} {3:>6} {c[0]:>11.3f} ")
+            itp.write(f"{c[1]:>11.3f} {c[2]:>11.3f} {c[3]:>11.3f} {c[4]:>11.3f} {c[5]:>11.3f}\n")
 
         # inversion dihedrals
-        if len(terms['dihedral/inversion']) > 0:
+        if len(terms["dihedral/inversion"]) > 0:
             itp.write("; inversion dihedrals \n")
-            itp.write(';   ai     aj     ak     al      f          c0          c1          c2\n')
+            itp.write(";   ai     aj     ak     al      f          c0          c1          c2\n")
 
-        for dihed in terms['dihedral/inversion']:
+        for dihed in terms["dihedral/inversion"]:
             ids = dihed.atomids + 1
             c0, c1, c2 = convert_to_inversion_rb(dihed.fconst, dihed.equ)
-            itp.write(f'{ids[0]:>6} {ids[1]:>6} {ids[2]:>6} {ids[3]:>6} {3:>6}'
-                      f'{c0:>11.3f} {c1:>11.3f} {c2:>11.3f} {0:>11.1f} {0:>11.1f} {0:>11.1f}\n')
+            itp.write(
+                f"{ids[0]:>6} {ids[1]:>6} {ids[2]:>6} {ids[3]:>6} {3:>6}"
+                f"{c0:>11.3f} {c1:>11.3f} {c2:>11.3f} {0:>11.1f} {0:>11.1f} {0:>11.1f}\n"
+            )
 
     def write_itp_exclusions(self, itp):
         if any(len(exclusion) > 0 for exclusion in self.exclusions):
@@ -301,8 +348,8 @@ class ForceField():
         for i, exclusion in enumerate(self.exclusions):
             if len(exclusion) > 0:
                 exclusion = sorted(set(exclusion))
-                itp.write("{} ".format(i+1))
-                itp.write(("{} "*len(exclusion)).format(*exclusion))
+                itp.write("{} ".format(i + 1))
+                itp.write(("{} " * len(exclusion)).format(*exclusion))
                 itp.write("\n")
 
     def make_pairs(self, neighbors, non_bonded):
@@ -315,47 +362,54 @@ class ForceField():
                         polar_pairs.append([a1, non_bonded.alpha_map[a2]])
                     if a1 in non_bonded.alpha_map.keys():
                         polar_pairs.append([a2, non_bonded.alpha_map[a1]])
-                    if a1 in non_bonded.alpha_map.keys() and a2 in non_bonded.alpha_map.keys():
+                    if (a1 in non_bonded.alpha_map.keys() and a2 in non_bonded.alpha_map.keys()):
                         polar_pairs.append([non_bonded.alpha_map[a1], non_bonded.alpha_map[a2]])
 
-        return non_bonded.pairs+polar_pairs
+        return non_bonded.pairs + polar_pairs
 
     def make_exclusions(self, non_bonded, neighbors, exclude_all):
         exclusions = [[] for _ in range(self.n_atoms)]
 
         # input exclusions  for exclusions if outside of n_excl
-        for a1, a2 in non_bonded.exclusions+non_bonded.pairs:
-            if all([a2 not in neighbors[i][a1] for i in range(self.n_excl+1)]):
-                exclusions[a1].append(a2+1)
+        for a1, a2 in non_bonded.exclusions + non_bonded.pairs:
+            if all([a2 not in neighbors[i][a1] for i in range(self.n_excl + 1)]):
+                exclusions[a1].append(a2 + 1)
 
         # fragment capping atom exclusions
         for i in exclude_all:
-            exclusions[i].extend(np.arange(1, self.n_atoms+1))
+            exclusions[i].extend(np.arange(1, self.n_atoms + 1))
 
         if self.polar:
-            exclusions = self.polarize_exclusions(non_bonded.alpha_map, non_bonded.exclusions,
-                                                  neighbors, exclude_all, exclusions)
+            exclusions = self.polarize_exclusions(
+                non_bonded.alpha_map,
+                non_bonded.exclusions,
+                neighbors,
+                exclude_all,
+                exclusions,
+            )
 
         return exclusions
 
-    def polarize_exclusions(self, alpha_map, input_exclusions, neighbors, exclude_all, exclusions):
+    def polarize_exclusions(
+        self, alpha_map, input_exclusions, neighbors, exclude_all, exclusions
+    ):
         n_polar_atoms = len(alpha_map.keys())
         exclusions.extend([[] for _ in range(n_polar_atoms)])
 
         # input exclusions
         for exclu in input_exclusions:
             if exclu[0] in alpha_map.keys():
-                exclusions[alpha_map[exclu[0]]].append(exclu[1]+1)
+                exclusions[alpha_map[exclu[0]]].append(exclu[1] + 1)
             if exclu[1] in alpha_map.keys():
-                exclusions[alpha_map[exclu[1]]].append(exclu[0]+1)
+                exclusions[alpha_map[exclu[1]]].append(exclu[0] + 1)
             if exclu[0] in alpha_map.keys() and exclu[1] in alpha_map.keys():
-                exclusions[alpha_map[exclu[0]]].append(alpha_map[exclu[1]]+1)
+                exclusions[alpha_map[exclu[0]]].append(alpha_map[exclu[1]] + 1)
 
         # fragment capping atom exclusions
         for i in exclude_all:
-            exclusions[i].extend(np.arange(self.n_atoms+1, self.n_atoms+n_polar_atoms+1))
+            exclusions[i].extend(np.arange(self.n_atoms + 1, self.n_atoms + n_polar_atoms + 1))
             if i in alpha_map.keys():
-                exclusions[alpha_map[i]].extend(np.arange(1, self.n_atoms+n_polar_atoms+1))
+                exclusions[alpha_map[i]].extend(np.arange(1, self.n_atoms + n_polar_atoms + 1))
 
         return exclusions
 
@@ -369,7 +423,7 @@ class ForceField():
                 atom_dict[sym] = 1
             else:
                 atom_dict[sym] += 1
-            atom_names.append(f'{sym}{atom_dict[sym]}')
+            atom_names.append(f"{sym}{atom_dict[sym]}")
         return atom_names
 
     def add_restraints(self, restraints, directory, fc=1000):
@@ -377,9 +431,9 @@ class ForceField():
             itp.write("[ dihedral_restraints ]\n")
             itp.write(";  ai    aj    ak    al  type       phi   dp   kfac\n")
             for restraint in restraints:
-                a1, a2, a3, a4 = restraint[0]+1
+                a1, a2, a3, a4 = restraint[0] + 1
                 phi = np.degrees(restraint[1])
-                itp.write(f'{a1:>5} {a2:>5} {a3:>5} {a4:>5} {1:>5} {phi:>10.4f}  0.0  {fc}\n')
+                itp.write(f"{a1:>5} {a2:>5} {a3:>5} {a4:>5} {1:>5} {phi:>10.4f}  0.0  {fc}\n")
 
     def set_charge(self, non_bonded):
         q = np.copy(non_bonded.q)
@@ -473,3 +527,4 @@ class ForceField():
 
     #             elif in_section == "pairs":
     #                 self.pairs.append(sorted([int(line[0]), int(line[1])]))
+    # fmt: on


### PR DESCRIPTION
This pull request introduces the implementation of the Adaptive Biasing Force (ABF) technique in QForce, aimed at enhancing the capability of the software in obtaining Molecular Mechanics Potential Energy Surface (PES) profiles for dihedral angles. The ABF method offers a significant improvements in terms of accuracy of the MM energy landscape, particularly for challenging systems with complex PES.

### Implementation Details
- The ABF method applies an adaptive bias to the dihedral angles during molecular dynamics simulations, enhancing the sampling of the free energy landscape.
- This implementation involves the integration of an ABF module within the QForce framework, ensuring compatibility and ease of use with existing functionalities.
- Users should be able to configure ABF-related parameters directly within QForce.
- The method should be designed to be versatile and fit into the automatic worfklow of QForce

### Functions to be implemented - Checklist
- [ ] automatic box sizing and consequently number of argon atoms
- [ ] automatic multithread based on atom numbers for ABF run
- [ ] automatic check for gromacs-colvars availability (and suggestions for available gmx executables?)
- [ ] automatic timestep selection based on the presence of hydrogens
- [ ] automatic increase of ABF run duration if histogram features elements with 0
- [ ] implementation of logging module
- [ ] run test suite
- [ ] write ad-hoc tests
- [ ] implement compatibility with Gromacs 2024